### PR TITLE
Fix typo in serverless.yml instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install --save-dev serverless-plugin-epsagon
 When installing with NPM, add the plugin to your `serverless.yml` file:
 ```yaml
 plugins:
-  - serveless-plugin-epsagon
+  - serverless-plugin-epsagon
 ```
 For the best results, make sure this is the first plugin specified in your
 plugins list.


### PR DESCRIPTION
I copied/pasted the original instructions, and it bombed due to this typo.