### PR TITLE
feat(config): add ignoredKeys and urlsToIgnore

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Available options:
 |`metadataOnly`   |Optional          |`false`           |Whether to send only the metadata (`true`) or also the payloads (`false`)                                                                     |
 |`handlersDirName`|Optional          |`epsagon_handlers`|Customize the name of the directory Epsagon stores its handlers in. Do not use this option unless you know what you are doing.                |
 |`packageJsonPath`|Optional          |`./package.json`  |Customize the path of your `package.json`                                                                                                     |
-|`collectorURL`|Optional          |`-`  |The address of the trace collector to send trace to                                                                                                     |
+|`collectorURL`   |Optional          |`-`               |The address of the trace collector to send trace to                                                                                           |
+|`ignoredKeys`    |Optional          |`-`               |May contain strings (will perform a loose match, so that First Name also matches first_name)                                                  |
+|`urlsToIgnore`   |Optional          |`-`               |Ignore HTTP calls to specific domains                                                                                                         |
 
 ### Function Level Options
 These options are defined at the function level, under the `epsagon` member of your function in the `serverless.yml` file.

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -4,11 +4,21 @@ const DEFAULT_WRAPPERS = {
   tsnode: 'lambdaWrapper',
 };
 
-const WRAPPER_CODE = ({relativePath, method, wrapper, token, appName, collectorUrl, metadataOnly, urlsToIgnore, ignoredKeys}) => {
+const WRAPPER_CODE = ({
+  relativePath,
+  method,
+  wrapper,
+  token,
+  appName,
+  collectorUrl,
+  metadataOnly,
+  urlsToIgnore,
+  ignoredKeys,
+}) => {
   const commonNode = `
 
-${urlsToIgnore ? `process.env.EPSAGON_URLS_TO_IGNORE = process.env.EPSAGON_URLS_TO_IGNORE || '${urlsToIgnore}';` : ""} 
-${ignoredKeys ? `process.env.EPSAGON_IGNORED_KEYS = process.env.EPSAGON_IGNORED_KEYS || '${ignoredKeys}';` : ""} 
+${urlsToIgnore ? `process.env.EPSAGON_URLS_TO_IGNORE = process.env.EPSAGON_URLS_TO_IGNORE || '${urlsToIgnore}';` : ''} 
+${ignoredKeys ? `process.env.EPSAGON_IGNORED_KEYS = process.env.EPSAGON_IGNORED_KEYS || '${ignoredKeys}';` : ''} 
 
 epsagon.init({
     token: '${token}',
@@ -25,8 +35,8 @@ try:
     import epsagon
     import os
         
-    ${urlsToIgnore ? `os.environ['EPSAGON_URLS_TO_IGNORE'] = '${urlsToIgnore}' if 'EPSAGON_URLS_TO_IGNORE' not in os.environ else os.environ['EPSAGON_URLS_TO_IGNORE']` : ""}
-    ${ignoredKeys ? `os.environ['EPSAGON_IGNORED_KEYS'] = '${ignoredKeys}' if 'EPSAGON_IGNORED_KEYS' not in os.environ else os.environ['EPSAGON_IGNORED_KEYS']` : ""}
+    ${urlsToIgnore ? `os.environ['EPSAGON_URLS_TO_IGNORE'] = '${urlsToIgnore}' if 'EPSAGON_URLS_TO_IGNORE' not in os.environ else os.environ['EPSAGON_URLS_TO_IGNORE']` : ''}
+    ${ignoredKeys ? `os.environ['EPSAGON_IGNORED_KEYS'] = '${ignoredKeys}' if 'EPSAGON_IGNORED_KEYS' not in os.environ else os.environ['EPSAGON_IGNORED_KEYS']` : ''}
     
     null = None  # used to ignore arguments
     undefined = None  # used to ignore arguments
@@ -83,7 +93,9 @@ export function generateWrapperCode(
   func,
   epsagonConf
 ) {
-  const { collectorURL, token, appName, metadataOnly, urlsToIgnore, ignoredKeys } = epsagonConf;
+  const {
+    collectorURL, token, appName, metadataOnly, urlsToIgnore, ignoredKeys,
+  } = epsagonConf;
   const { wrapper = DEFAULT_WRAPPERS[func.language] } = (func.epsagon || {});
 
   const relativePath = (
@@ -100,7 +112,7 @@ export function generateWrapperCode(
     collectorUrl: collectorURL ? `'${collectorURL}'` : undefined,
     metadataOnly: metadataOnly === true ? '1' : '0',
     urlsToIgnore,
-    ignoredKeys
+    ignoredKeys,
   });
 }
 

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -4,52 +4,65 @@ const DEFAULT_WRAPPERS = {
   tsnode: 'lambdaWrapper',
 };
 
-const WRAPPER_CODE = {
-  python: `
-from RELATIVE_PATH import METHOD as METHOD_internal
-METHOD = METHOD_internal
+const WRAPPER_CODE = ({relativePath, method, wrapper, token, appName, collectorUrl, metadataOnly, urlsToIgnore, ignoredKeys}) => {
+  const commonNode = `
+
+process.env.EPSAGON_URLS_TO_IGNORE = process.env.EPSAGON_URLS_TO_IGNORE || '${urlsToIgnore}'; 
+process.env.EPSAGON_IGNORED_KEYS = process.env.EPSAGON_IGNORED_KEYS || '${ignoredKeys}'; 
+
+epsagon.init({
+    token: '${token}',
+    appName: '${appName}',
+    traceCollectorURL: ${collectorUrl},
+    metadataOnly: Boolean(${metadataOnly})
+});`;
+
+  return ({
+    python: `
+from ${relativePath} import ${method} as ${method}_internal
+${method} = ${method}_internal
 try:
     import epsagon
-
+    import os
+        
+    os.environ['EPSAGON_URLS_TO_IGNORE'] = '${urlsToIgnore}' if 'EPSAGON_URLS_TO_IGNORE' not in os.environ else os.environ['EPSAGON_URLS_TO_IGNORE']
+    os.environ['EPSAGON_IGNORED_KEYS'] = '${ignoredKeys}' if 'EPSAGON_IGNORED_KEYS' not in os.environ else os.environ['EPSAGON_IGNORED_KEYS']
+    
     null = None  # used to ignore arguments
     undefined = None  # used to ignore arguments
     epsagon.init(
-        token='TOKEN',
-        app_name='APP_NAME',
-        collector_url=COLLECTOR_URL,
-        metadata_only=bool(METADATA_ONLY)
+        token='${token}',
+        app_name='${appName}',
+        collector_url=${collectorUrl},
+        metadata_only=bool(${metadataOnly})
     )
 
-    METHOD = epsagon.WRAPPER_TYPE(METHOD_internal)
+    ${method} = epsagon.${wrapper}(${method}_internal)
 except:
     print('Warning: Epsagon package not found. The function will not be monitored')
 `,
-  node: `
+    node: `
 const epsagon = require('epsagon');
-const epsagonHandler = require('../RELATIVE_PATH.js');
+const epsagonHandler = require('../${relativePath}.js');
 
 epsagon.init({
-    token: 'TOKEN',
-    appName: 'APP_NAME',
-    traceCollectorURL: COLLECTOR_URL,
-    metadataOnly: Boolean(METADATA_ONLY)
+    token: '${token}',
+    appName: '${appName}',
+    traceCollectorURL: ${collectorUrl},
+    metadataOnly: Boolean(${metadataOnly})
 });
 
-exports.METHOD = epsagon.WRAPPER_TYPE(epsagonHandler.METHOD);
+exports.${method} = epsagon.${wrapper}(epsagonHandler.${method});
 `,
-  tsnode: `
+    tsnode: `
 import * as epsagon from 'epsagon';
-import * as epsagonHandler from '../RELATIVE_PATH';
+import * as epsagonHandler from '../${relativePath}';
 
-epsagon.init({
-    token: 'TOKEN',
-    appName: 'APP_NAME',
-    traceCollectorURL: COLLECTOR_URL,
-    metadataOnly: Boolean(METADATA_ONLY)
-});
+${commonNode}
 
-export const METHOD = epsagon.WRAPPER_TYPE(epsagonHandler.METHOD);
+export const ${method} = epsagon.${wrapper}(epsagonHandler.${method});
 `,
+  });
 };
 
 const FILE_NAME_BY_LANG_GENERATORS = {
@@ -70,25 +83,25 @@ export function generateWrapperCode(
   func,
   epsagonConf
 ) {
-  const {
-    wrapper = DEFAULT_WRAPPERS[func.language],
-    appName = epsagonConf.appName,
-  } = (func.epsagon || {});
+  const { collectorURL, token, appName, metadataOnly, urlsToIgnore, ignoredKeys } = epsagonConf;
+  const { wrapper = DEFAULT_WRAPPERS[func.language] } = (func.epsagon || {});
 
   const relativePath = (
     func.language === 'python' ?
       func.relativePath.replace(/\//g, '.').replace(/\\/g, '.') :
       func.relativePath
   );
-  return WRAPPER_CODE[func.language]
-    .replace(/RELATIVE_PATH/g, relativePath)
-    .replace(/METHOD/g, func.method)
-    .replace(/WRAPPER_TYPE/g, wrapper)
-    .replace(/TOKEN/g, epsagonConf.token)
-    .replace(/APP_NAME/g, appName)
-    .replace(/COLLECTOR_URL/g, epsagonConf.collectorURL ?
-      `'${epsagonConf.collectorURL}'` : undefined)
-    .replace(/METADATA_ONLY/g, epsagonConf.metadataOnly === true ? '1' : '0');
+  return WRAPPER_CODE[func.language]({
+    relativePath,
+    method: func.method,
+    wrapper,
+    token,
+    appName,
+    collectorUrl: collectorURL ? `'${collectorURL}'` : undefined,
+    metadataOnly: metadataOnly === true ? '1' : '0',
+    urlsToIgnore,
+    ignoredKeys
+  });
 }
 
 /**

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -7,8 +7,8 @@ const DEFAULT_WRAPPERS = {
 const WRAPPER_CODE = ({relativePath, method, wrapper, token, appName, collectorUrl, metadataOnly, urlsToIgnore, ignoredKeys}) => {
   const commonNode = `
 
-process.env.EPSAGON_URLS_TO_IGNORE = process.env.EPSAGON_URLS_TO_IGNORE || '${urlsToIgnore}'; 
-process.env.EPSAGON_IGNORED_KEYS = process.env.EPSAGON_IGNORED_KEYS || '${ignoredKeys}'; 
+${urlsToIgnore ? `process.env.EPSAGON_URLS_TO_IGNORE = process.env.EPSAGON_URLS_TO_IGNORE || '${urlsToIgnore}';` : ""} 
+${ignoredKeys ? `process.env.EPSAGON_IGNORED_KEYS = process.env.EPSAGON_IGNORED_KEYS || '${ignoredKeys}';` : ""} 
 
 epsagon.init({
     token: '${token}',
@@ -25,8 +25,8 @@ try:
     import epsagon
     import os
         
-    os.environ['EPSAGON_URLS_TO_IGNORE'] = '${urlsToIgnore}' if 'EPSAGON_URLS_TO_IGNORE' not in os.environ else os.environ['EPSAGON_URLS_TO_IGNORE']
-    os.environ['EPSAGON_IGNORED_KEYS'] = '${ignoredKeys}' if 'EPSAGON_IGNORED_KEYS' not in os.environ else os.environ['EPSAGON_IGNORED_KEYS']
+    ${urlsToIgnore ? `os.environ['EPSAGON_URLS_TO_IGNORE'] = '${urlsToIgnore}' if 'EPSAGON_URLS_TO_IGNORE' not in os.environ else os.environ['EPSAGON_URLS_TO_IGNORE']` : ""}
+    ${ignoredKeys ? `os.environ['EPSAGON_IGNORED_KEYS'] = '${ignoredKeys}' if 'EPSAGON_IGNORED_KEYS' not in os.environ else os.environ['EPSAGON_IGNORED_KEYS']` : ""}
     
     null = None  # used to ignore arguments
     undefined = None  # used to ignore arguments


### PR DESCRIPTION
## Summary
The `ignoredKeys` and `urlsToIgnore` configuration variables are available both on [epsagon/epsagon-node](https://github.com/epsagon/epsagon-node#filter-sensitive-data) and [epsagon/epsagon-python](https://github.com/epsagon/epsagon-python#filter-sensitive-data) as well as via matching environment variables (couldn't find the documentation for these).  

This PR allows them to be set via the serverless plugin configuration.  

## How
I opted for setting these on the corresponding environment variable **if one is not set already.**  
The motivation was that there's some manipulation to be done on both inputs to convert them from a comma delimited string of values to an array of strings (and possibly, going forward, also predicates and regular expression objects on the node implementation) - this type of processing of either the environment variable or the serverless plugin would preferably occur in [epsagon-node](https://github.com/epsagon/epsagon-node/blob/468e7ab91bd3b5ec81ab2708057c70601b21e397/src/config.js#L81) and its corresponding Python code.  

## What's Changed
- Added the configuration variables
- Replaced regex string replace in the wrapper code to es string literal interpolation - had to do that as the generated code was about to have a substring of the current convention `IGNORED_KEYS` in `EPSAGON_IGNORED_KEYS`
- DRYd out the node wrapper template part
- Updated the docs