### PR TITLE
Feature/added labels to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Available options:
 |`collectorURL`   |Optional          |`-`               |The address of the trace collector to send trace to                                                                                           |
 |`ignoredKeys`    |Optional          |`-`               |May contain strings (will perform a loose match, so that First Name also matches first_name)                                                  |
 |`urlsToIgnore`   |Optional          |`-`               |Ignore HTTP calls to specific domains                                                                                                         |
+|`labels`         |Optional          |`[]`              |Global labels applied to all traces                                                                                                           |
 
 ### Function Level Options
 These options are defined at the function level, under the `epsagon` member of your function in the `serverless.yml` file.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Available options:
 |`collectorURL`   |Optional          |`-`               |The address of the trace collector to send trace to                                                                                           |
 |`ignoredKeys`    |Optional          |`-`               |May contain strings (will perform a loose match, so that First Name also matches first_name)                                                  |
 |`urlsToIgnore`   |Optional          |`-`               |Ignore HTTP calls to specific domains                                                                                                         |
-|`labels`         |Optional          |`[]`              |Global labels applied to all traces                                                                                                           |
+|`labels`         |Optional          |`[]`              |Global labels applied to all traces (Not available for Python)                                                                                |
 
 ### Function Level Options
 These options are defined at the function level, under the `epsagon` member of your function in the `serverless.yml` file.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Available options:
 |`collectorURL`   |Optional          |`-`               |The address of the trace collector to send trace to                                                                                           |
 |`ignoredKeys`    |Optional          |`-`               |May contain strings (will perform a loose match, so that First Name also matches first_name)                                                  |
 |`urlsToIgnore`   |Optional          |`-`               |Ignore HTTP calls to specific domains                                                                                                         |
-|`labels`         |Optional          |`[]`              |Global labels applied to all traces (Not available for Python)                                                                                |
+|`labels`         |Optional          |`[]`              |Global labels applied to all traces. For example "[['key', 'val']]". (Not available for Python)                                                                                |
 
 ### Function Level Options
 These options are defined at the function level, under the `epsagon` member of your function in the `serverless.yml` file.

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -117,7 +117,7 @@ export function generateWrapperCode(
     metadataOnly: metadataOnly === true ? '1' : '0',
     urlsToIgnore,
     ignoredKeys,
-    labels: labels ? labels : [],
+    labels: labels || [],
   })[func.language];
 }
 

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -57,13 +57,7 @@ except:
 const epsagon = require('epsagon');
 const epsagonHandler = require('../${relativePath}.js');
 
-epsagon.init({
-    token: '${token}',
-    appName: '${appName}',
-    traceCollectorURL: ${collectorUrl},
-    metadataOnly: Boolean(${metadataOnly}),
-    labels: ${labels}
-});
+${commonNode}
 
 exports.${method} = epsagon.${wrapper}(epsagonHandler.${method});
 `,

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -14,6 +14,7 @@ const WRAPPER_CODE = ({
   metadataOnly,
   urlsToIgnore,
   ignoredKeys,
+  labels,
 }) => {
   const commonNode = `
 
@@ -24,7 +25,8 @@ epsagon.init({
     token: '${token}',
     appName: '${appName}',
     traceCollectorURL: ${collectorUrl},
-    metadataOnly: Boolean(${metadataOnly})
+    metadataOnly: Boolean(${metadataOnly}),
+    labels: ${labels}
 });`;
 
   return ({
@@ -44,7 +46,8 @@ try:
         token='${token}',
         app_name='${appName}',
         collector_url=${collectorUrl},
-        metadata_only=bool(${metadataOnly})
+        metadata_only=bool(${metadataOnly}),
+        labels: ${labels}
     )
 
     ${method} = epsagon.${wrapper}(${method}_internal)
@@ -59,7 +62,8 @@ epsagon.init({
     token: '${token}',
     appName: '${appName}',
     traceCollectorURL: ${collectorUrl},
-    metadataOnly: Boolean(${metadataOnly})
+    metadataOnly: Boolean(${metadataOnly}),
+    labels: ${labels}
 });
 
 exports.${method} = epsagon.${wrapper}(epsagonHandler.${method});
@@ -94,7 +98,7 @@ export function generateWrapperCode(
   epsagonConf
 ) {
   const {
-    collectorURL, token, appName, metadataOnly, urlsToIgnore, ignoredKeys,
+    collectorURL, token, appName, metadataOnly, urlsToIgnore, ignoredKeys, labels,
   } = epsagonConf;
   const { wrapper = DEFAULT_WRAPPERS[func.language] } = (func.epsagon || {});
 
@@ -113,6 +117,7 @@ export function generateWrapperCode(
     metadataOnly: metadataOnly === true ? '1' : '0',
     urlsToIgnore,
     ignoredKeys,
+    labels: labels ? labels : [],
   })[func.language];
 }
 

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -46,8 +46,7 @@ try:
         token='${token}',
         app_name='${appName}',
         collector_url=${collectorUrl},
-        metadata_only=bool(${metadataOnly}),
-        labels: ${labels}
+        metadata_only=bool(${metadataOnly})
     )
 
     ${method} = epsagon.${wrapper}(${method}_internal)


### PR DESCRIPTION
Added the new `labels` param that is now available via `Epsagon.init(..)` call.