### PR TITLE
Patching v1.9.0

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -26,7 +26,7 @@ epsagon.init({
     appName: '${appName}',
     traceCollectorURL: ${collectorUrl},
     metadataOnly: Boolean(${metadataOnly}),
-    labels: ${labels}
+    labels: ${labels.length ? JSON.stringify(labels) : labels}
 });`;
 
   return ({


### PR DESCRIPTION
Patching the `label` value serialization.

When the value set in `serverless.yml` is a nested array.  String interpolation does not render that nested list structure.

Worked
```
custom:
   epsagon:
      labels: '[ [ "env": "bleh" ]]'
```

Did not work
```
custom:
   epsagon:
      labels:
        -
          - env
          - bleh
```