### PR TITLE
fix(ignored keys): set variables to epsagon config instead of env vars

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -18,15 +18,14 @@ const WRAPPER_CODE = ({
 }) => {
   const commonNode = `
 
-${urlsToIgnore ? `process.env.EPSAGON_URLS_TO_IGNORE = process.env.EPSAGON_URLS_TO_IGNORE || '${urlsToIgnore}';` : ''} 
-${ignoredKeys ? `process.env.EPSAGON_IGNORED_KEYS = process.env.EPSAGON_IGNORED_KEYS || '${ignoredKeys}';` : ''} 
-
 epsagon.init({
     token: '${token}',
     appName: '${appName}',
     traceCollectorURL: ${collectorUrl},
     metadataOnly: Boolean(${metadataOnly}),
-    labels: ${labels || '[]'}
+    labels: ${labels || '[]'},
+    urlPatternsToIgnore: ${urlsToIgnore ? "['".concat(urlsToIgnore.replace(',', "', '")).concat("']") : '[]'},
+    ignoredKeys: ${ignoredKeys ? "['".concat(ignoredKeys.replace(',', "', '")).concat("']") : '[]'},
 });`;
 
   return ({


### PR DESCRIPTION
the environment variables in node are being set after epsagon reads them (even though `epsagon.init` is called later) so they are moved to the configuration.