### PR TITLE
Update README regarding epsagon on package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ functions:
 ```
 
 ### [Node.js] `Epsagon's Node library must be installed in order to use this plugin!` error:
-The plugin verifies that `epsagon` module exists on your `./package.json` before deployment.
+The plugin verifies that `epsagon` module exists in your `dependencies` section of your `./package.json` before deployment.
 In some cases, the `package.json` might be in a different path. You can easily update it using `packageJsonPath` parameter, for example:
 ```yaml
 custom:


### PR DESCRIPTION
to remember people that epsagon should be installed NOT as a devDep
wording is not great but it's better than not having that info there.

maybe better:
> Before deployment, the plugin verifies if `epsagon` module is listed under `package.json`'s **`dependencies`** section.