### PR TITLE
feat(index.js): support ignoring payloads for Python (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Available options:
 |`collectorURL`   |Optional          |`-`               |The address of the trace collector to send trace to                                                                                           |
 |`ignoredKeys`    |Optional          |`-`               |May contain strings (will perform a loose match, so that First Name also matches first_name)                                                  |
 |`urlsToIgnore`   |Optional          |`-`               |Ignore HTTP calls to specific domains                                                                                                         |
+|`payloadsToIgnore` |Optional          |`-`               | Array of dictionaries to not instrument. Example: `'{"source": "serverless-plugin-warmup"}'` (Not yet available for Node)                                                                                                   |
 |`labels`         |Optional          |`[]`              |Global labels applied to all traces. For example "[['key', 'val']]". (Not available for Python)                                                                                |
 |`wrapper`|Optional          |`lambda_wrapper/lambdaWrapper` | The wrapper to use to wrap this function. See [wrappers](#wrappers)|                                                       |
 

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -13,17 +13,21 @@ const WRAPPER_CODE = ({
   collectorUrl,
   metadataOnly,
   urlsToIgnore,
+  payloadsToIgnore,
   ignoredKeys,
   labels,
 }) => {
   const commonNode = `
-
   if (!process.env.EPSAGON_IGNORED_KEYS) {
     process.env.EPSAGON_IGNORED_KEYS = "${ignoredKeys || ''}";
   }
 
   if (!process.env.EPSAGON_URLS_TO_IGNORE) {
     process.env.EPSAGON_URLS_TO_IGNORE = "${urlsToIgnore || ''}";
+  }
+  
+  if (!process.env.EPSAGON_PAYLOADS_TO_IGNORE) {
+    process.env.EPSAGON_PAYLOADS_TO_IGNORE = "${payloadsToIgnore || ''}";
   }
 
 epsagon.init({
@@ -44,6 +48,7 @@ try:
         
     ${urlsToIgnore ? `os.environ['EPSAGON_URLS_TO_IGNORE'] = '${urlsToIgnore}' if 'EPSAGON_URLS_TO_IGNORE' not in os.environ else os.environ['EPSAGON_URLS_TO_IGNORE']` : ''}
     ${ignoredKeys ? `os.environ['EPSAGON_IGNORED_KEYS'] = '${ignoredKeys}' if 'EPSAGON_IGNORED_KEYS' not in os.environ else os.environ['EPSAGON_IGNORED_KEYS']` : ''}
+    ${payloadsToIgnore ? `os.environ['EPSAGON_PAYLOADS_TO_IGNORE'] = '${payloadsToIgnore}' if 'EPSAGON_PAYLOADS_TO_IGNORE' not in os.environ else os.environ['EPSAGON_PAYLOADS_TO_IGNORE']` : ''}
     
     null = None  # used to ignore arguments
     undefined = None  # used to ignore arguments
@@ -96,7 +101,7 @@ export function generateWrapperCode(
   epsagonConf
 ) {
   const {
-    collectorURL, token, appName, metadataOnly, urlsToIgnore, ignoredKeys, labels,
+    collectorURL, token, appName, metadataOnly, urlsToIgnore, payloadsToIgnore, ignoredKeys, labels,
   } = epsagonConf;
   const { wrapper = DEFAULT_WRAPPERS[func.language] } = (func.epsagon || {});
 
@@ -106,6 +111,7 @@ export function generateWrapperCode(
       func.relativePath
   );
   const labelsFormatted = typeof labels === 'object' ? JSON.stringify(labels) : labels;
+  const ignoredKeysFormatted = typeof payloadsToIgnore === 'object' ? JSON.stringify(payloadsToIgnore) : payloadsToIgnore;
 
   return WRAPPER_CODE({
     relativePath,
@@ -116,6 +122,7 @@ export function generateWrapperCode(
     collectorUrl: collectorURL ? `'${collectorURL}'` : undefined,
     metadataOnly: metadataOnly === true ? '1' : '0',
     urlsToIgnore,
+    payloadsToIgnore: ignoredKeysFormatted,
     ignoredKeys,
     labels: labelsFormatted,
   })[func.language];

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,7 @@ export default class ServerlessEpsagonPlugin {
               collectorURL: { type: 'string' },
               ignoredKeys: { type: 'string' },
               urlsToIgnore: { type: 'string' },
+              payloadsToIgnore: { type: 'array' },
               labels: { type: 'string' },
               wrapper: { type: 'string' },
             },


### PR DESCRIPTION
Fixes #106 but is blocked on https://github.com/epsagon/epsagon-python/pull/373

Example usage:

```
  epsagon:
    token: "foo"
    appName: "bar"
    payloadsToIgnore:
      - foo: bar
      - baz: quuz
  ```
  
  Which results in generated wrapper code getting this line added, which in turn can is used by the python library:
  
 ```
<SNIP>
os.environ['EPSAGON_PAYLOADS_TO_IGNORE'] = '[{"foo":"bar"},{"baz":"quuz"}]' if 'EPSAGON_PAYLOADS_TO_IGNORE' not in os.environ else os.environ['EPSAGON_PAYLOADS_TO_IGNORE']
<SNIP>
```