### PR TITLE
Node: fix quoting, set sane default when no payloads to ignore

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -27,7 +27,7 @@ const WRAPPER_CODE = ({
   }
   
   if (!process.env.EPSAGON_PAYLOADS_TO_IGNORE) {
-    process.env.EPSAGON_PAYLOADS_TO_IGNORE = "${payloadsToIgnore || ''}";
+    process.env.EPSAGON_PAYLOADS_TO_IGNORE = '${payloadsToIgnore}';
   }
 
 epsagon.init({
@@ -111,7 +111,7 @@ export function generateWrapperCode(
       func.relativePath
   );
   const labelsFormatted = typeof labels === 'object' ? JSON.stringify(labels) : labels;
-  const ignoredKeysFormatted = typeof payloadsToIgnore === 'object' ? JSON.stringify(payloadsToIgnore) : payloadsToIgnore;
+  const ignoredKeysFormatted = typeof payloadsToIgnore === 'object' ? JSON.stringify(payloadsToIgnore) : '';
 
   return WRAPPER_CODE({
     relativePath,


### PR DESCRIPTION
Found while testing https://github.com/epsagon/epsagon-node/pull/509

Two issues:

Firstly, using double quotes around a stringified JSON object rendering something illegal:

```Error ---------------------------------------------------
 
  Error: Module parse failed: Unexpected token (15:49)
  File was processed with these loaders:
   * ./node_modules/@zeit/ncc/dist/ncc/loaders/empty-loader.js
   * ./node_modules/@zeit/ncc/dist/ncc/loaders/relocate-loader.js
   * ./node_modules/@zeit/ncc/dist/ncc/loaders/shebang-loader.js
  You may need an additional loader to handle the result of these loaders.
  |   
  |   if (!process.env.EPSAGON_PAYLOADS_TO_IGNORE) {
  >     process.env.EPSAGON_PAYLOADS_TO_IGNORE = "[{"source":"serverless-plugin-warmup"}]";
  |   }
  | 
      at /Users/ottojongerius/repos/trove/phoebe/node_modules/@zeit/ncc/dist/ncc/index.js.cache.js:3:63173
      at eval (eval at create (/Users/ottojongerius/repos/trove/phoebe/node_modules/@zeit/ncc/dist/ncc/index.js.cache.js:1:275040), <anonymous>:13:1)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

Secondly, current code in the plugin, for node, caused payloadsToIgnore to equate to false instead of an empty string. This caused the node library changes in https://github.com/epsagon/epsagon-node/pull/509 to call .filter() on false, which failed when no payloads to ignore are configured.