### PR TITLE
Fix repository link typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "author": "Epsagon Team",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/epsagon/serverless-plugin-espagon/issues"
+    "url": "https://github.com/epsagon/serverless-plugin-epsagon/issues"
   },
-  "homepage": "https://github.com/epsagon/serverless-plugin-espagon#readme",
+  "homepage": "https://github.com/epsagon/serverless-plugin-epsagon#readme",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Some links in `package.json` seem broken