### PR TITLE
Typescript handlers are created for "node" runtime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,7 @@ export default class ServerlessEpsagonPlugin {
       const matchingFiles = glob.sync(`${relativePath}.*`);
       if (
         matchingFiles.length > 0 &&
-           (matchingFiles[0].endsWith('.ts') ||
+           ((matchingFiles[0].endsWith('.ts') && (!matchingFiles[0].endsWith('d.ts'))) ||
             matchingFiles[0].endsWith('.tsx'))
       ) {
         // This is a good enough test for now. lets treat it as TS.

--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,7 @@ export default class ServerlessEpsagonPlugin {
       const matchingFiles = glob.sync(`${relativePath}.*`);
       if (
         matchingFiles.length > 0 &&
-           ((matchingFiles[0].endsWith('.ts') && (!matchingFiles[0].endsWith('d.ts'))) ||
+           ((matchingFiles[0].endsWith('.ts') && (!matchingFiles[0].endsWith('.d.ts'))) ||
             matchingFiles[0].endsWith('.tsx'))
       ) {
         // This is a good enough test for now. lets treat it as TS.


### PR DESCRIPTION
- When the configured runtime for the function/service provider is 'node' , the plugin was creating a list of typescript handlers instead of javascript handlers. The  distribution folder can have declaration files (index.d.ts), thus with the changes, it will skip the overrule of "ts-node" as a language.